### PR TITLE
Initialize highlighter on CMS page view

### DIFF
--- a/js/bubble/highlighter.js
+++ b/js/bubble/highlighter.js
@@ -9,6 +9,17 @@ BubbleHighlighter.prototype = {
             autoCloseTags:  true,
             wysiwygEnabled: false
         }, options || {});
+        
+        // Refresh highlighter when changing tabs, for instance on the CMS page view
+        document.observe('dom:loaded', function() {
+            $$('.tab-item-link').each(function (element) {
+                element.observe('click', function () {
+                    $$('.CodeMirror').each(function (element) {
+                        element.CodeMirror.refresh();
+                    });
+                });
+            });
+        });
     },
     setup: function(cm, textarea) {
         // Update doc content


### PR DESCRIPTION
On the CMS page view the highlighter is not initialized by default if the WYSIWYG editor is disabled by default.
Only when clicking in the textarea. This fix makes sure the highlighter get's initialized when changing tabs.